### PR TITLE
Release drafter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ import BotService from './services/botService';
 const _botService: BotService = new BotService();
 
 export = (app: Probot) => {
+  app.on('release.created', async (context: HookContext) => {
+    await _botService.updateDraftRelease(context);
+  });
+
   app.on(
     ['pull_request.opened', 'pull_request.reopened', 'pull_request.ready_for_review'],
     async (context: HookContext) => {
@@ -15,6 +19,11 @@ export = (app: Probot) => {
 
   app.on('pull_request.edited', async (context: HookContext) => {
     await _botService.handlePR(context, PRAction.EDITED);
+  });
+
+  app.on('pull_request.merged', async (context: HookContext) => {
+    // Ensure that Changelogs on existing Draft Releases are updated.
+    await _botService.updateDraftRelease(context);
   });
 
   /**

--- a/src/model/model_ghMilestone.ts
+++ b/src/model/model_ghMilestone.ts
@@ -1,0 +1,16 @@
+import GHUser from "./model_ghUser";
+
+export default interface GHMilestone {
+  url: string,
+  number: number,
+  title: string,
+  description: '',
+  creator: GHUser,
+  open_issues: number,
+  closed_issues: number,
+  state: string,
+  created_at: string,
+  updated_at: string,
+  due_on: string,
+  closed_at: string
+}

--- a/src/model/model_ghPR.ts
+++ b/src/model/model_ghPR.ts
@@ -1,16 +1,19 @@
+import GHLabel from './model_ghLabel';
 import GHUser from './model_ghUser';
+import GHMilestone from './model_ghMilestone';
 
 export default interface GHPr {
   url: string,
   number: number,
-  state: string,
+  state: 'open' | 'closed' | 'all',
   title: string,
   user: GHUser,
   body: string,
+  labels: GHLabel[],
   created_at: string,
   updated_at: string,
   closed_at?: string,
   merged_at?: string,
-  milestone?: string,
-  draft: boolean
+  milestone?: GHMilestone,
+  draft?: boolean
 }

--- a/src/model/model_ghRelease.ts
+++ b/src/model/model_ghRelease.ts
@@ -1,0 +1,15 @@
+import GHUser from './model_ghUser';
+
+export default interface GHRelease {
+  url: string,
+  id: number,
+  author: GHUser,
+  tag_name: string,
+  target_commitish: string, // Branch that is used for release.
+  name: string,
+  draft: boolean,
+  prerelease: boolean,
+  created_at: string,
+  published_at: string | null,
+  body: string
+}

--- a/src/model/model_labelArchive.ts
+++ b/src/model/model_labelArchive.ts
@@ -47,7 +47,8 @@ export default class LabelArchive {
 
   private findGHLabel(ghLabel: GHLabel): Label | undefined {
     return this.collatePresetLabels().find(
-      (label: Label) => label.name === ghLabel.name && label.color === ghLabel.color && label.desc === ghLabel.color
+      (label: Label) =>
+        label.name === ghLabel.name && label.color === ghLabel.color && label.desc === ghLabel.description
     );
   }
 

--- a/src/model/model_pr.ts
+++ b/src/model/model_pr.ts
@@ -1,7 +1,94 @@
+import GHPr from './model_ghPR';
+import Label from './model_label';
+import User from './model_user';
+import { LABEL_ARCHIVE } from '../constants/const_labels';
+import { LabelCollectionType } from './model_labelCollection';
+
 export enum PRAction {
   READY_FOR_REVIEW = 'Ready for Review',
   EDITED = 'Edited',
   CLOSED = 'Closed',
   OPENED = 'Opened',
   CONVERTED_TO_DRAFT = 'Converted to Draft',
+}
+
+export default class PullRequest {
+  private _number: number;
+  private _state: 'open' | 'closed' | 'all';
+  private _title: string;
+  private _user: User;
+  private _body: string;
+  private _labels: Label[];
+  private _created_at: string;
+  private _updated_at: string;
+  private _closed_at?: string;
+  private _merged_at?: string;
+  private _draft?: boolean;
+
+  constructor(ghPR: GHPr) {
+    this._number = ghPR.number;
+    this._state = ghPR.state;
+    this._title = ghPR.title;
+    this._user = new User(ghPR.user);
+    this._body = ghPR.body;
+    this._labels = LABEL_ARCHIVE.mapGHLabels(ghPR.labels);
+    this._created_at = ghPR.created_at;
+    this._updated_at = ghPR.updated_at;
+    this._closed_at = ghPR?.closed_at;
+    this._merged_at = ghPR?.merged_at;
+    this._draft = ghPR?.draft;
+  }
+
+  /**
+   * Extracts an 'Issue' Label from set of Labels.
+   * @returns Label that is an 'Issue' Label.
+   */
+  public getIssueLabel(): Label | undefined {
+    // console.log(this._labels);
+    return this._labels.find((label: Label) => label.name.includes(LabelCollectionType.IssueCollection));
+  }
+
+  public get draft(): boolean | undefined {
+    return this._draft;
+  }
+
+  public get merged_at(): string | undefined {
+    return this._merged_at;
+  }
+
+  public get closed_at(): string | undefined {
+    return this._closed_at;
+  }
+
+  public get updated_at(): string {
+    return this._updated_at;
+  }
+
+  public get created_at(): string {
+    return this._created_at;
+  }
+
+  public get body(): string {
+    return this._body;
+  }
+
+  public get title(): string {
+    return this._title;
+  }
+
+  public get labels(): Label[] {
+    return this._labels;
+  }
+
+  public get user(): User {
+    return this._user;
+  }
+
+  public get state(): string {
+    return this._state;
+  }
+
+  public get number(): number {
+    return this._number;
+  }
 }

--- a/src/model/model_user.ts
+++ b/src/model/model_user.ts
@@ -1,0 +1,31 @@
+import GHUser from './model_ghUser';
+
+export default class User {
+  private _login: string;
+  private _id: number;
+  private _url: string;
+  private _type: string;
+
+  constructor(ghUser: GHUser) {
+    this._login = ghUser.login;
+    this._id = ghUser.id;
+    this._url = ghUser.url;
+    this._type = ghUser.type;
+  }
+
+  public get login(): string {
+    return this._login;
+  }
+
+  public get id(): number {
+    return this._id;
+  }
+
+  public get url(): string {
+    return this._url;
+  }
+
+  public get type(): string {
+    return this._type;
+  }
+}

--- a/src/services/botService.ts
+++ b/src/services/botService.ts
@@ -39,7 +39,9 @@ export default class BotService {
       prHandlingResults.push(await this.handlePRLabelReplacement(context, prAction));
     }
 
-    return prHandlingResults.reduce((previousResults: boolean, currentResult: boolean) => previousResults && currentResult);
+    return prHandlingResults.reduce(
+      (previousResults: boolean, currentResult: boolean) => previousResults && currentResult
+    );
   }
 
   /**

--- a/src/services/botService.ts
+++ b/src/services/botService.ts
@@ -2,19 +2,41 @@ import LabelService from './labelService';
 import PRService from './prService';
 import ContextService, { HookContext } from './contextService';
 import IssueService from './issueService';
+import ReleaseService from './releaseService';
 import { PRAction } from '../model/model_pr';
+import GHRelease from '../model/model_ghRelease';
 
 export default class BotService {
   private _labelService: LabelService;
   private _prService: PRService;
   private _contextService: ContextService;
   private _issueService: IssueService;
+  private _releaseService: ReleaseService;
 
   constructor() {
     this._labelService = new LabelService();
     this._prService = new PRService();
     this._contextService = new ContextService();
     this._issueService = new IssueService();
+    this._releaseService = new ReleaseService();
+  }
+
+  public async updateDraftRelease(context: HookContext): Promise<boolean> {
+    const existingRelease: GHRelease | undefined = await this._contextService.getLastReleaseRetriever(
+      context,
+      'draft'
+    )();
+
+    if (!existingRelease) {
+      return true;
+    }
+
+    return this._releaseService.updateReleaseChangelog(
+      existingRelease,
+      this._contextService.getLastReleaseRetriever(context, 'published'),
+      this._contextService.getPRRetriever(context),
+      this._contextService.getReleaseBodyUpdater(context)
+    );
   }
 
   /**

--- a/src/services/releaseService.ts
+++ b/src/services/releaseService.ts
@@ -1,0 +1,103 @@
+import GHPr from '../model/model_ghPR';
+import GHRelease from '../model/model_ghRelease';
+import PullRequest from '../model/model_pr';
+
+export default class ReleaseService {
+  private readonly CHANGELOG_TITLE: string = '## Changelog';
+  private readonly OTHERS_HEADER: string = '### 🧱 Others\n';
+  private readonly headerGenerator: (labelName: string) => string = (labelName: string) => {
+    const [emoji, title, ..._]: [emoji?: string, title?: string, ..._: string[]] = labelName.split(/ .*\./);
+    return `### ${emoji} ${title}\n`;
+  };
+
+  /**
+   * Updates a release body with a changelog of all PRs merged after the last release.
+   * @param currentRelease - GHRelease object that is the currrent drafted release.
+   * @param last_release_retriever - Function that fetches the last published release.
+   * @param merged_pr_retriever - Function that retreives merged pull requests based on
+   * input filters.
+   * @param release_body_updater - Funtion that updates the current release body.
+   * @returns promise of true of true if release body updating was successful false
+   * otherwise.
+   */
+  public async updateReleaseChangelog(
+    currentRelease: GHRelease,
+    last_release_retriever: () => Promise<GHRelease | undefined>,
+    merged_pr_retriever: ({
+      pr_per_page,
+      pages,
+      filter,
+      date_range,
+    }: {
+      pr_per_page?: number;
+      pages?: number;
+      filter?: 'draft' | 'merged';
+      date_range?: { startDate?: Date; endDate?: Date };
+    }) => Promise<GHPr[]>,
+    release_body_updater: (currentRelease: GHRelease, newReleaseBody: string) => Promise<boolean>
+  ): Promise<boolean> {
+    //! Do not make changes on a release that is not a draft.
+    if (!currentRelease.draft) {
+      return true;
+    }
+
+    const lastRelease: GHRelease | undefined = await last_release_retriever();
+    const recentlyMergedPRs: PullRequest[] = (
+      await merged_pr_retriever({
+        filter: 'merged',
+        date_range: { startDate: lastRelease ? new Date(lastRelease.published_at!) : undefined },
+      })
+    ).map((ghPr: GHPr) => new PullRequest(ghPr));
+
+    const newReleaseBody: string = this.addChangelogToReleaseBody(
+      currentRelease,
+      this.draftChangelog(recentlyMergedPRs)
+    );
+    return await release_body_updater(currentRelease, newReleaseBody);
+  }
+
+  /**
+   *
+   * @param currentRelease - GHRelease object.
+   * @param changelog - string that is to be added to a release body.
+   * @returns string containing newly updated release body.
+   */
+  private addChangelogToReleaseBody(currentRelease: GHRelease, changelog: string): string {
+    const changelogRegex: RegExp = new RegExp(`${this.CHANGELOG_TITLE}\n*.*`, 'gs');
+    const isChangelogInBody: boolean = changelogRegex.test(currentRelease.body);
+
+    if (!isChangelogInBody) {
+      return `${currentRelease.body.trimEnd()}\n\n${changelog}`;
+    }
+
+    const existingChangelog: string = currentRelease.body.match(changelogRegex)![0];
+    return currentRelease.body.replace(existingChangelog, changelog).trimEnd();
+  }
+
+  /**
+   * Creates a string containing a formatted changelog
+   * @param pullRequests - List of Pull Requests to add to changelog.
+   * @returns string representing a format list of changes.
+   */
+  private draftChangelog(pullRequests: PullRequest[]): string {
+    const changelogCollation: { [changelogHeader: string]: string } = {};
+
+    pullRequests.forEach((pullRequest: PullRequest) => {
+      const labelName: string | undefined = pullRequest.getIssueLabel()?.name;
+
+      // * Complex 1 Liner that Updates / Creates new Collated Changelog.
+      changelogCollation[labelName ? this.headerGenerator(labelName) : this.OTHERS_HEADER] = changelogCollation[
+        labelName ? this.headerGenerator(labelName) : this.OTHERS_HEADER
+      ]
+        ? `${changelogCollation[this.OTHERS_HEADER]}- ${pullRequest.title} (#${pullRequest.number})\n`
+        : `- ${pullRequest.title} (#${pullRequest.number})\n`;
+    });
+
+    let changelog: string = `${this.CHANGELOG_TITLE}\n`;
+    for (const header in changelogCollation) {
+      changelog = `${changelog}${header}${changelogCollation[header]}`;
+    }
+
+    return changelog;
+  }
+}


### PR DESCRIPTION
Fixes #11 

Commit Message:
```
Add Automatic Draft Release Changelog

If there are draft releases present, the latest draft release
will have an automatically updating changelog with merged
PRs based on issue labels assigned to them.

If there are no draft releases, when a draft is created, a change
log is automatically added to the bottom of the Release Body.

NOTE: Typically, keep in mind that the end of the release body should
be kept for changelogs. (Anything below the changelog will be removed
when bot auto-updates content.)
```