### PR TITLE
CommitMessage Checking Halted for Merged

### DIFF
--- a/src/services/prService.ts
+++ b/src/services/prService.ts
@@ -153,7 +153,7 @@ export default class PRService {
     prLabelReplacer: (removalLabelName: string[], replacementLabelNames: string[]) => Promise<boolean>,
     issueRetriever: (issueNumber: number) => Promise<GHIssue | undefined>
   ): Promise<boolean> {
-    if (ghPr?.draft || !ghPr.body) {
+    if (ghPr?.draft || !ghPr.body || ghPr?.merged_at) {
       return true;
     }
 
@@ -204,7 +204,7 @@ export default class PRService {
     prCommenter: (pr: GHPr, comment: string) => Promise<boolean>
   ): Promise<boolean> {
     // Do not check if PR is still in draft.
-    if (ghPr?.draft || !ghPr.body) {
+    if (ghPr?.draft || !ghPr.body || ghPr?.merged_at) {
       return true;
     }
 


### PR DESCRIPTION
Fixes #25 

Aspect Label will also not be assigned once merger has taken place.

Commit Message:
```
Halt Commit Validation & Label Assignment for Merged PRs

Previously, commit message validation & aspect
label assignment would still carry on if a merged PR was
edited. This has now been stopped.
```